### PR TITLE
Shader change to assume real world positions

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,7 +6,7 @@ All notable changes to the `bevy voxel plot` crate will be documented in this fi
 
 ### Added:
 
-* ...
+* Assume voxel vertices are real world coordinates in shader.
 
 # 2.0.1
 

--- a/assets/shaders/instancing.wgsl
+++ b/assets/shaders/instancing.wgsl
@@ -17,6 +17,7 @@ struct VertexOutput {
 
 @vertex
 fn vertex(vertex: Vertex) -> VertexOutput {
+    // NOTE: Assumes vertex positions are real world positions
     let world_position = vertex.position * vertex.i_pos_scale.w + vertex.i_pos_scale.xyz;
 
     var out: VertexOutput;

--- a/assets/shaders/instancing.wgsl
+++ b/assets/shaders/instancing.wgsl
@@ -1,4 +1,5 @@
-#import bevy_pbr::mesh_functions::{get_world_from_local, mesh_position_local_to_clip}
+#import bevy_pbr::mesh_functions::{mesh_position_local_to_world}
+#import bevy_pbr::view_transformations::position_world_to_clip
 
 struct Vertex {
     @location(0) position: vec3<f32>,
@@ -16,16 +17,10 @@ struct VertexOutput {
 
 @vertex
 fn vertex(vertex: Vertex) -> VertexOutput {
-    let position = vertex.position * vertex.i_pos_scale.w + vertex.i_pos_scale.xyz;
+    let world_position = vertex.position * vertex.i_pos_scale.w + vertex.i_pos_scale.xyz;
+
     var out: VertexOutput;
-    // NOTE: Passing 0 as the instance_index to get_world_from_local() is a hack
-    // for this example as the instance_index builtin would map to the wrong
-    // index in the Mesh array. This index could be passed in via another
-    // uniform instead but it's unnecessary for the example.
-    out.clip_position = mesh_position_local_to_clip(
-        get_world_from_local(0u),
-        vec4<f32>(position, 1.0)
-    );
+    out.clip_position = position_world_to_clip(world_position);
     out.color = vertex.i_color;
     return out;
 }


### PR DESCRIPTION
Due to behaviour observed in #2, alter shader to assume vertices are real world positions, which fixes the unwanted transforms with other entities present. 